### PR TITLE
Added serial number to device enumeration information

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ class USBRelay
         const connectedRelays = devices.filter(device => {
                 return device.product.indexOf("USBRelay") !== -1;
         });
+        connectedRelays.forEach(device=>{
+            device.serial = new USBRelay(device.path).getSerialNumber();
+        });
         return connectedRelays;
     }
         

--- a/index.js
+++ b/index.js
@@ -18,7 +18,12 @@ class USBRelay
                 return device.product.indexOf("USBRelay") !== -1;
         });
         connectedRelays.forEach(device=>{
-            device.serial = new USBRelay(device.path).getSerialNumber();
+            try{
+                device.serial = new USBRelay(device.path).getSerialNumber();
+            }
+            catch(e){
+                device.serial = "";
+            }
         });
         return connectedRelays;
     }


### PR DESCRIPTION
I've been creating a node-red library for these relays, and it seems like a wise choice to prepopulate the device list with the actual serial numbers of the relays for better discovery.