### PR TITLE
Update index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class USBRelay
     {
         const devices = HID.devices();
         const connectedRelays = devices.filter(device => {
-                return device.product.indexOf("USBRelay") !== -1;
+                return device.product && device.product.indexOf("USBRelay") !== -1;
         });
         connectedRelays.forEach(device=>{
             try{


### PR DESCRIPTION
Thanks for bringing in my latest update @josephdadams. This is a tiny patch that just prevents devices without a product name from causing an unnecessary exception to be thrown. I was able to cause this when mucking about with other obscure hid devices.