### PR TITLE
Fix for HID devices without product

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,6 @@ class USBRelay
         {
                 // Device path was not provided, so let's select the first connected device.
                 const devices = HID.devices();
-                console.log(devices);
                 const connectedRelays = devices.filter(device => {
                     return device.product && device.product.indexOf("USBRelay") !== -1;
                 });

--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ class USBRelay
     {
         const devices = HID.devices();
         const connectedRelays = devices.filter(device => {
-                return device.product && device.product.indexOf("USBRelay") !== -1;
+            return device.product && device.product.indexOf("USBRelay") !== -1;
         });
         connectedRelays.forEach(device=>{
             try{
@@ -34,11 +34,12 @@ class USBRelay
         {
                 // Device path was not provided, so let's select the first connected device.
                 const devices = HID.devices();
+                console.log(devices);
                 const connectedRelays = devices.filter(device => {
-                        return device.product && device.product.indexOf("USBRelay") !== -1;
+                    return device.product && device.product.indexOf("USBRelay") !== -1;
                 });
                 if (!connectedRelays.length) {
-                        throw new Error('No USB Relays are connected.');
+                    throw new Error('No USB Relays are connected.');
                 }
                 this.device = new HID.HID(connectedRelays[0].path);
         }


### PR DESCRIPTION
@josephdadams here there's a fix for an error that I encountered while trying to port the old listener client to v3.0.0
For clarification, I attach `console.log(HID.devices());`:
```js
[
  {
    vendorId: 1578,
    productId: 16642,
    path: '\\\\?\\hid#vid_062a&pid_4102&col01#7&6e6ba4b&0&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}',
    manufacturer: 'MOSART Semi.',
    product: '2.4G Wireless Mouse',
    release: 259,
    interface: -1,
    usagePage: 1,
    usage: 2
  },
  {
    vendorId: 1578,
    productId: 16642,
    path: '\\\\?\\hid#vid_062a&pid_4102&col02#7&6e6ba4b&0&0001#{4d1e55b2-f16f-11cf-88cb-001111000030}',
    manufacturer: 'MOSART Semi.',
    product: '2.4G Wireless Mouse',
    release: 259,
    interface: -1,
    usagePage: 12,
    usage: 1
  },
  {
    vendorId: 1578,
    productId: 16642,
    path: '\\\\?\\hid#vid_062a&pid_4102&col03#7&6e6ba4b&0&0002#{4d1e55b2-f16f-11cf-88cb-001111000030}',
    manufacturer: 'MOSART Semi.',
    product: '2.4G Wireless Mouse',
    release: 259,
    interface: -1,
    usagePage: 61938,
    usage: 61938
  },
  {
    vendorId: 1,
    productId: 1,
    path: '\\\\?\\hid#hpq6001#3&3229b8bb&1&0000#{4d1e55b2-f16f-11cf-88cb-001111000030}',
    release: 1,
    interface: -1,
    usagePage: 1,
    usage: 12
  }
]
```